### PR TITLE
Fix replacement so that it works when a newline falls between 'the' and 'cloud'

### DIFF
--- a/src/chrome/content/cloud-to-butt.js
+++ b/src/chrome/content/cloud-to-butt.js
@@ -31,10 +31,10 @@
     {
         var v = textNode.nodeValue;
     
-        v = v.replace(/\bThe Cloud\b/g, "My Butt");
-        v = v.replace(/\bThe cloud\b/g, "My butt");
-        v = v.replace(/\bthe Cloud\b/g, "my Butt");
-        v = v.replace(/\bthe cloud\b/g, "my butt");
+        v = v.replace(/\bThe(\s+)Cloud\b/g, "My$1Butt");
+        v = v.replace(/\bThe(\s+)cloud\b/g, "My$1butt");
+        v = v.replace(/\bthe(\s+)Cloud\b/g, "my$1Butt");
+        v = v.replace(/\bthe(\s+)cloud\b/g, "my$1butt");
     
         textNode.nodeValue = v;
     }


### PR DESCRIPTION
While reading the following page:

http://www.debian.org/News/2012/20120425

I noticed that the extension was failing to do its job. Turns out there's a newline in the HTML source between the tokens "the" and "cloud".

So I fixed the regex replace so that it handles this situation.

You're welcome.

-jeff
